### PR TITLE
add debug for better failed route context

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "@conjurelabs/err": "0.0.2",
     "@conjurelabs/utils": "0.0.1",
-    "cors": "^2.8.4"
+    "cors": "^2.8.4",
+    "debug": "4.0.1"
   },
   "peerDependencies": {
     "express": ">=4"

--- a/sync-crawl.js
+++ b/sync-crawl.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const debug = require('debug')('route')
 const sortInsensitive = require('@conjurelabs/utils/Array/sort-insensitive')
 
 const defaultVerLookup = {
@@ -93,6 +94,7 @@ function syncCrawlRoutesDir(rootpath, verbLookup = defaultVerLookup) {
         try {
           routeInstance = require(routePath)
         } catch (err) {
+          debug(`${routePath} skipped - ${err.message}`)
           return null
         }
 


### PR DESCRIPTION
If a route fails to `require` (could be a valid `throw`) then it's helpful to see some debug info.

Added support for `DEBUG=*` or `DEBUG=route`