### PR TITLE
Expose file paths on routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conjurelabs/route",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "description": "Express routes made easy",
   "main": "index.js",
   "scripts": {

--- a/sync-crawl.js
+++ b/sync-crawl.js
@@ -208,7 +208,9 @@ function syncCrawlRoutesDir(rootpath, options = {}) {
         routePath: `/${uriPathTokens.join('/')}*`,
         filePath: mapping.filePath
       })
-      routes.push(mapping.routeInstance.expressRouter(mapping.verb, '/' + uriPathTokens.join('/')))
+      const newRoute = mapping.routeInstance.expressRouter(mapping.verb, '/' + uriPathTokens.join('/'))
+      newRoute.filePath = mapping.filePath
+      routes.push(newRoute)
     }
 
     // 2. removing applied wildcards
@@ -240,7 +242,9 @@ function syncCrawlRoutesDir(rootpath, options = {}) {
         routePath: `/${uriPathTokens.join('/')}`,
         filePath: mapping.filePath
       })
-      routes.push(mapping.routeInstance.expressRouter(mapping.verb, '/' + uriPathTokens.join('/')))
+      const newRoute = mapping.routeInstance.expressRouter(mapping.verb, '/' + uriPathTokens.join('/'))
+      newRoute.filePath = mapping.filePath
+      routes.push(newRoute)
     }
 
     return routes


### PR DESCRIPTION
Making it easier for consumers to be able to tell what files and handling each route, by adding `filePath` to each route object passed back by `sync-crawl`